### PR TITLE
Improve desktop entry (on Linux)

### DIFF
--- a/src/package/src/main.rs
+++ b/src/package/src/main.rs
@@ -39,12 +39,14 @@ macro_rules! DESKTOP_ENTRY_FMT {
     () => {
         "[Desktop Entry]
 Type=Application
-Version={}
+Version=1.5
 Name={}
 Icon={}
+Categories=Utility
 Exec={}
 Terminal=false
-X-GNOME-UsesNotifications=true"
+X-GNOME-UsesNotifications=true
+"
     };
 }
 
@@ -258,7 +260,7 @@ async fn main() -> Result<(), Error> {
                 desktopentry,
                 format!(
                     DESKTOP_ENTRY_FMT!(),
-                    pkg_version, pkg_name, pkg_name, pkg_name
+                    pkg_name, pkg_name, pkg_name
                 )
                 .as_bytes(),
             )


### PR DESCRIPTION
Set Version correctly ([to the .desktop file specification version][1]). Use a nice Name. Add an entry for Categories. Add a terminating newline.

The change to Name is because I think it looks nicer in desktop menus, notifications, etc. If you disagree with this change, please say so!

[1]: https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html#key-version